### PR TITLE
Removed BulkInsertOptions in InsertFromQuery() and added CommdandTimeout

### DIFF
--- a/N.EntityFramework.Extensions/N.EntityFramework.Extensions.nuspec
+++ b/N.EntityFramework.Extensions/N.EntityFramework.Extensions.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>N.EntityFramework.Extensions</id>
-    <version>1.4.3</version>
+    <version>1.4.4</version>
     <title>N.EntityFramework.Extensions</title>
     <authors>Northern25</authors>
     <owners>Northern25</owners>

--- a/N.EntityFramework.Extensions/Properties/AssemblyInfo.cs
+++ b/N.EntityFramework.Extensions/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.3")]
-[assembly: AssemblyFileVersion("1.4.3")]
+[assembly: AssemblyVersion("1.4.4")]
+[assembly: AssemblyFileVersion("1.4.4")]

--- a/N.EntityFramework.Extensions/Util/SqlUtil.cs
+++ b/N.EntityFramework.Extensions/Util/SqlUtil.cs
@@ -7,21 +7,21 @@ namespace N.EntityFramework.Extensions
 {
     internal static class SqlUtil
     {
-        internal static int ExecuteSql(string query, SqlConnection connection, SqlTransaction transaction, BulkOptions options)
+        internal static int ExecuteSql(string query, SqlConnection connection, SqlTransaction transaction, int? commandTimeout=null)
         {
             var sqlCommand = new SqlCommand(query, connection, transaction);
-            if (options?.CommandTimeout.HasValue ?? false)
+            if (commandTimeout.HasValue)
             {
-                sqlCommand.CommandTimeout = options.CommandTimeout.Value;
+                sqlCommand.CommandTimeout = commandTimeout.Value;
             }
             return sqlCommand.ExecuteNonQuery();
         }
-        internal static object ExecuteScalar(string query, SqlConnection connection, SqlTransaction transaction, BulkOptions options)
+        internal static object ExecuteScalar(string query, SqlConnection connection, SqlTransaction transaction, int? commandTimeout = null)
         {
             var sqlCommand = new SqlCommand(query, connection, transaction);
-            if (options?.CommandTimeout.HasValue ?? false)
+            if (commandTimeout.HasValue)
             {
-                sqlCommand.CommandTimeout = options.CommandTimeout.Value;
+                sqlCommand.CommandTimeout = commandTimeout.Value;
             }
             return sqlCommand.ExecuteScalar();
         }


### PR DESCRIPTION
Removed BulkDeleteOptions in DeleteFromQuery() and added CommandTimeout
Removed BulkUpdateOptions in UpdateFromQuery() and added Commandtimeout
Refactored SqlUtil.ExecuteSql, SqlUtil.ExecuteScalar to use CommandTimeout instead of BulkOptions
Updated nuget and assembly version to 1.4.4