### PR TITLE
Added connection string in Tests/Data/TestDbContext.cs to override EF…

### DIFF
--- a/N.EntityFramework.Extensions.Test/Data/TestDbContext.cs
+++ b/N.EntityFramework.Extensions.Test/Data/TestDbContext.cs
@@ -6,10 +6,11 @@ namespace N.EntityFramework.Extensions.Test.Data
 {
     public class TestDbContext : DbContext
     {
+        private static readonly string _connectionString = @"Data Source=(LocalDb)\MSSQLLocalDB;Initial Catalog = N.EntityFramework.Extensions.Test.Data.TestDbContext; Integrated Security = True; MultipleActiveResultSets=True";
         public virtual DbSet<Order> Orders { get; set;  }
         public virtual DbSet<Article> Articles { get; set;  }
 
-        public TestDbContext()
+        public TestDbContext() : base(_connectionString)
         {
             Database.SetInitializer(new MigrateDatabaseToLatestVersion<TestDbContext, TestDbConfiguration>());
         }

--- a/N.EntityFramework.Extensions/Data/DbContextExtensions.cs
+++ b/N.EntityFramework.Extensions/Data/DbContextExtensions.cs
@@ -781,7 +781,7 @@ namespace N.EntityFramework.Extensions
             {
                 var dbQuery = querable as DbQuery<T>;
                 var internalQuery = querable.GetPrivateFieldValue("InternalQuery");
-                var context = internalQuery.GetPrivateFieldValue("InternalContext");
+                var context = internalQuery.GetPrivateFieldValue("_internalContext");
                 dbConnection = context.GetPrivateFieldValue("Connection") as SqlConnection;
             }
             catch(Exception ex)

--- a/N.EntityFramework.Extensions/N.EntityFramework.Extensions.nuspec
+++ b/N.EntityFramework.Extensions/N.EntityFramework.Extensions.nuspec
@@ -13,7 +13,7 @@
 	<tags>EntityFramework Extensions</tags>
     <dependencies>
 	   <group targetFramework=".NETFramework4.5">
-		 <dependency id="EntityFramework" version="6.4.4" />
+		 <dependency id="EntityFramework" version="6.2.0" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
… 6.2.0 default connection string

Reduced the dependency from EF 6.4.4+ to 6.2.0+
Added a fix for getting the database connection from DBContext or IQuerable since it was crashing for EF 6.2.0