### PR TITLE
Fixed DateTime parameter bug in DeleteFromQuery, InsertFromQuery, Upd…

### DIFF
--- a/N.EntityFramework.Extensions.Test/Data/Order.cs
+++ b/N.EntityFramework.Extensions.Test/Data/Order.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace N.EntityFramework.Extensions.Test.Data
 {
@@ -8,9 +10,13 @@ namespace N.EntityFramework.Extensions.Test.Data
         public long Id { get; set; }
         public string ExternalId { get; set; }
         public decimal Price { get; set; }
+        public DateTime AddedDateTime { get; set; }
+        public DateTime? ModifiedDateTime { get; set; }
+        public bool Active { get; set; }
         public Order()
         {
-
+            AddedDateTime = DateTime.UtcNow;
+            Active = true;
         }
     }
 }

--- a/N.EntityFramework.Extensions/N.EntityFramework.Extensions.csproj
+++ b/N.EntityFramework.Extensions/N.EntityFramework.Extensions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.1</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <Version>1.5.1</Version>
+    <Version>1.5.2</Version>
     <Company>NorthernLight1</Company>
     <Copyright>Copyright ©  2021</Copyright>
     <Description>Entity Framework Extensions extends your DbContext with high-performance bulk operations: BulkDelete, BulkInsert, BulkMerge, BulkSync, BulkUpdate, Fetch, FromSqlQuery, DeleteFromQuery, InsertFromQuery, UpdateFromQuery, QueryToCsvFile, SqlQueryToCsvFile.

--- a/N.EntityFramework.Extensions/Sql/SqlBuilder.cs
+++ b/N.EntityFramework.Extensions/Sql/SqlBuilder.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data.Entity.Core.Objects;
+using System.Data.SqlClient;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
@@ -15,10 +17,12 @@ namespace N.EntityFramework.Extensions.Sql
         {
             get { return this.ToString(); }
         }
+        public SqlParameter[] Parameters { get; private set; }
         public List<SqlClause> Clauses { get; private set; }
-        private SqlBuilder(string sql)
+        private SqlBuilder(string sql, SqlParameter[] parameters = null)
         {
             Clauses = new List<SqlClause>();
+            Parameters = parameters;
             Initialize(sql);
         }
 
@@ -81,6 +85,18 @@ namespace N.EntityFramework.Extensions.Sql
         public static SqlBuilder Parse(string sql)
         {
             return new SqlBuilder(sql);
+        }
+        public static SqlBuilder Parse<T>(string sql, ObjectQuery<T> objectQuery)
+        {
+            var sqlParameters = new List<SqlParameter>();
+            if (objectQuery != null)
+            {
+                foreach (var parameter in objectQuery.Parameters)
+                {
+                    sqlParameters.Add(new SqlParameter(parameter.Name, parameter.Value));
+                }
+            }
+            return new SqlBuilder(sql, sqlParameters.ToArray());
         }
         public void ChangeToDelete(string expression)
         {


### PR DESCRIPTION
…ateFromQuery

Updated test case UpdateFromQuery_With_DateTime to cover valid DateTime parameter instead of a null value
Added test cases for DeleteFromQuery and InsertFromQuery to cover DateTime parameters
Fixed BulkInsert so that it uses BulkOptions.UsePermanentTable instead of always passing true
Updated Nuget version to 1.5.2