### PR TITLE
BulkInsert Not Working With Database First Model

### DIFF
--- a/N.EntityFramework.Extensions/Data/BulkInsertOptions.cs
+++ b/N.EntityFramework.Extensions/Data/BulkInsertOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 

--- a/N.EntityFramework.Extensions/Data/DbContextExtensions.cs
+++ b/N.EntityFramework.Extensions/Data/DbContextExtensions.cs
@@ -838,8 +838,8 @@ namespace N.EntityFramework.Extensions
                             .GetItems<EntityContainer>(DataSpace.CSpace)
                                   .Single()
                                   .EntitySets
-                                  .Single(s => s.ElementType.FullName == entityType.FullName 
-                                    || (entityType.BaseType != null && s.ElementType.FullName == entityType.BaseType.FullName));
+                                  .Single(s => (s.ElementType.Name == entityType.Name)
+                                    || (entityType.BaseType != null && s.ElementType.Name == entityType.BaseType.Name));
 
             // Find the mapping between conceptual and storage model for this entity set
             var mappings = metadata.GetItems<EntityContainerMapping>(DataSpace.CSSpace)
@@ -851,7 +851,7 @@ namespace N.EntityFramework.Extensions
             var columns = new List<ScalarPropertyMapping>();
             var conditions = new List<ConditionPropertyMapping>();
             foreach (var mapping in mappings.EntityTypeMappings
-                .Where(o => o.EntityType == null || o.EntityType.FullName == entityType.FullName))
+                .Where(o => o.EntityType == null || o.EntityType.Name == entityType.Name))
             {
                 foreach(var propertyMapping in mapping.Fragments.Single().PropertyMappings.OfType<ScalarPropertyMapping>().ToList())
                 {

--- a/N.EntityFramework.Extensions/Data/TableMapping.cs
+++ b/N.EntityFramework.Extensions/Data/TableMapping.cs
@@ -23,7 +23,7 @@ namespace N.EntityFramework.Extensions
         public TableMapping(EntitySet entitySet, EntityType entityType, EntitySetMapping mapping, 
             List<ScalarPropertyMapping> columns, List<ConditionPropertyMapping> conditions)
         {
-            var storeEntitySet = mapping.EntityTypeMappings.First(o => o.EntityType != null && o.EntityType.FullName == entityType.FullName).Fragments.Single().StoreEntitySet;
+            var storeEntitySet = mapping.EntityTypeMappings.First(o => o.EntityType != null && o.EntityType.Name == entityType.Name).Fragments.Single().StoreEntitySet;
             
             EntitySet = entitySet;
             EntityType = entityType;

--- a/N.EntityFramework.Extensions/N.EntityFramework.Extensions.csproj
+++ b/N.EntityFramework.Extensions/N.EntityFramework.Extensions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.1</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <Version>1.5.3</Version>
+    <Version>1.5.4</Version>
     <Company>NorthernLight1</Company>
     <Copyright>Copyright ©  2021</Copyright>
     <Description>Entity Framework Extensions extends your DbContext with high-performance bulk operations: BulkDelete, BulkInsert, BulkMerge, BulkSync, BulkUpdate, Fetch, FromSqlQuery, DeleteFromQuery, InsertFromQuery, UpdateFromQuery, QueryToCsvFile, SqlQueryToCsvFile.


### PR DESCRIPTION
Fixed various bugs that prevented a Database First model from using the Bulk Operations

Updated Nuget version to 1.5.4