### PR TITLE
Cleaned Up Old Test Cases for BulkDelete

### DIFF
--- a/N.EntityFramework.Extensions.Test/DbContextExtensions/BulkDelete.cs
+++ b/N.EntityFramework.Extensions.Test/DbContextExtensions/BulkDelete.cs
@@ -20,9 +20,21 @@ namespace N.EntityFramework.Extensions.Test.DbContextExtensions
             Assert.IsTrue(newTotal == 0, "Must be 0 to indicate all records were deleted");
         }
         [TestMethod]
+        public void With_Default_Options_Tpc()
+        {
+            var dbContext = SetupDbContext(true, PopulateDataMode.Tpc);
+            var customers = dbContext.TpcPeople.OfType<TpcCustomer>().ToList();
+            int rowsDeleted = dbContext.BulkDelete(customers, options => { options.DeleteOnCondition = (s, t) => s.Id == t.Id; });
+            var newCustomers = dbContext.TpcPeople.OfType<TpcCustomer>().Count();
+
+            Assert.IsTrue(customers.Count > 0, "There must be tpcCustomer records in database");
+            Assert.IsTrue(rowsDeleted == customers.Count, "The number of rows deleted must match the count of existing rows in database");
+            Assert.IsTrue(newCustomers == 0, "Must be 0 to indicate all records were deleted");
+        }
+        [TestMethod]
         public void With_Default_Options_Tph()
         {
-            var dbContext = SetupDbContext(true);
+            var dbContext = SetupDbContext(true, PopulateDataMode.Tph);
             var customers = dbContext.TphPeople.OfType<TphCustomer>().ToList();
             int rowsDeleted = dbContext.BulkDelete(customers);
             var newCustomers = dbContext.TphPeople.OfType<TphCustomer>().Count();

--- a/N.EntityFramework.Extensions.Test/DbContextExtensions/BulkDeleteAsync.cs
+++ b/N.EntityFramework.Extensions.Test/DbContextExtensions/BulkDeleteAsync.cs
@@ -21,9 +21,21 @@ namespace N.EntityFramework.Extensions.Test.DbContextExtensions
             Assert.IsTrue(newTotal == 0, "Must be 0 to indicate all records were deleted");
         }
         [TestMethod]
+        public async Task With_Default_Options_Tpc()
+        {
+            var dbContext = SetupDbContext(true,PopulateDataMode.Tpc);
+            var customers = dbContext.TpcPeople.OfType<TpcCustomer>().ToList();
+            int rowsDeleted = await dbContext.BulkDeleteAsync(customers, options => { options.DeleteOnCondition = (s, t) => s.Id == t.Id; });
+            var newCustomers = dbContext.TpcPeople.OfType<TpcCustomer>().Count();
+
+            Assert.IsTrue(customers.Count > 0, "There must be tpcCustomer records in database");
+            Assert.IsTrue(rowsDeleted == customers.Count, "The number of rows deleted must match the count of existing rows in database");
+            Assert.IsTrue(newCustomers == 0, "Must be 0 to indicate all records were deleted");
+        }
+        [TestMethod]
         public async Task With_Default_Options_Tph()
         {
-            var dbContext = SetupDbContext(true);
+            var dbContext = SetupDbContext(true, PopulateDataMode.Tph);
             var customers = dbContext.TphPeople.OfType<TphCustomer>().ToList();
             int rowsDeleted = await dbContext.BulkDeleteAsync(customers);
             var newCustomers = dbContext.TphPeople.OfType<TphCustomer>().Count();

--- a/N.EntityFramework.Extensions.Test/DbContextExtensions/BulkInsert.cs
+++ b/N.EntityFramework.Extensions.Test/DbContextExtensions/BulkInsert.cs
@@ -115,6 +115,38 @@ namespace N.EntityFramework.Extensions.Test.DbContextExtensions
             Assert.IsTrue(autoMapIdentityMatched, "The auto mapping of ids of entities that were merged failed to match up");
         }
         [TestMethod]
+        public void With_Options_IgnoreColumns()
+        {
+            var dbContext = SetupDbContext(false);
+            var orders = new List<Order>();
+            for (int i = 0; i < 20000; i++)
+            {
+                orders.Add(new Order { Id = i, ExternalId = i.ToString(), Price = 1.57M, Active = true });
+            }
+            int oldTotal = dbContext.Orders.Where(o => o.Price <= 10 && o.ExternalId == null).Count();
+            int rowsInserted = dbContext.BulkInsert(orders, options => { options.UsePermanentTable = true; options.IgnoreColumns = o => new { o.ExternalId };});
+            int newTotal = dbContext.Orders.Where(o => o.Price <= 10 && o.ExternalId == null).Count();
+
+            Assert.IsTrue(rowsInserted == orders.Count, "The number of rows inserted must match the count of order list");
+            Assert.IsTrue(newTotal - oldTotal == rowsInserted, "The new count minus the old count should match the number of rows inserted.");
+        }
+        [TestMethod]
+        public void With_Options_InputColumns()
+        {
+            var dbContext = SetupDbContext(false);
+            var orders = new List<Order>();
+            for (int i = 0; i < 20000; i++)
+            {
+                orders.Add(new Order { Id = i, ExternalId = i.ToString(), Price = 1.57M, Active = true });
+            }
+            int oldTotal = dbContext.Orders.Where(o => o.Price == 1.57M && o.ExternalId == null && o.Active == true).Count();
+            int rowsInserted = dbContext.BulkInsert(orders, options => { options.UsePermanentTable = true; options.InputColumns = o => new { o.Price, o.Active, o.AddedDateTime }; });
+            int newTotal = dbContext.Orders.Where(o => o.Price == 1.57M && o.ExternalId == null && o.Active == true).Count();
+
+            Assert.IsTrue(rowsInserted == orders.Count, "The number of rows inserted must match the count of order list");
+            Assert.IsTrue(newTotal - oldTotal == rowsInserted, "The new count minus the old count should match the number of rows inserted.");
+        }
+        [TestMethod]
         public void With_Options_KeepIdentity()
         {
             var dbContext = SetupDbContext(false);

--- a/N.EntityFramework.Extensions.Test/DbContextExtensions/BulkUpdateAsync.cs
+++ b/N.EntityFramework.Extensions.Test/DbContextExtensions/BulkUpdateAsync.cs
@@ -32,7 +32,7 @@ namespace N.EntityFramework.Extensions.Test.DbContextExtensions
         [TestMethod]
         public async Task With_Default_Options_Tph()
         {
-            var dbContext = SetupDbContext(true);
+            var dbContext = SetupDbContext(true, PopulateDataMode.Tph);
             var customers = dbContext.TphPeople.Where(o => o.LastName != "BulkUpdateTest").OfType<TphCustomer>().ToList();
             var vendors = dbContext.TphPeople.OfType<TphVendor>().ToList();
             foreach (var customer in customers)

--- a/N.EntityFramework.Extensions.Test/DbContextExtensions/DbContextExtensionsBase.cs
+++ b/N.EntityFramework.Extensions.Test/DbContextExtensions/DbContextExtensionsBase.cs
@@ -6,6 +6,12 @@ using System.Diagnostics;
 
 namespace N.EntityFramework.Extensions.Test.DbContextExtensions
 {
+    public enum PopulateDataMode
+    {
+        Normal,
+        Tpc,
+        Tph
+    }
     [TestClass]
     public class DbContextExtensionsBase
     {
@@ -15,99 +21,138 @@ namespace N.EntityFramework.Extensions.Test.DbContextExtensions
             TestDbContext dbContext = new TestDbContext();
             dbContext.Database.CreateIfNotExists();
         }
-        protected TestDbContext SetupDbContext(bool populateData)
+        protected TestDbContext SetupDbContext(bool populateData, PopulateDataMode mode = PopulateDataMode.Normal)
         {
             TestDbContext dbContext = new TestDbContext();
             dbContext.Orders.Truncate();
             dbContext.Products.Truncate();
             dbContext.Database.ClearTable("TphPeople");
+            dbContext.Database.ClearTable("TpcCustomer");
+            dbContext.Database.ClearTable("TpcVendor");
             dbContext.Database.DropTable("OrdersUnderTen", true);
             dbContext.Database.DropTable("OrdersLast30Days", true);
             if (populateData)
             {
-                var orders = new List<Order>();
-                int id = 1;
-                for (int i = 0; i < 2050; i++)
+                if (mode == PopulateDataMode.Normal)
                 {
-                    DateTime addedDateTime = DateTime.UtcNow.AddDays(-id);
-                    orders.Add(new Order
+                    var orders = new List<Order>();
+                    int id = 1;
+                    for (int i = 0; i < 2050; i++)
                     {
-                        Id = id,
-                        ExternalId = string.Format("id-{0}", i),
-                        Price = 1.25M,
-                        AddedDateTime = addedDateTime,
-                        ModifiedDateTime = addedDateTime.AddHours(3)
-                    });
-                    id++;
-                }
-                for (int i = 0; i < 1050; i++)
-                {
-                    orders.Add(new Order { Id = id, Price = 5.35M });
-                    id++;
-                }
-                for (int i = 0; i < 2050; i++)
-                {
-                    orders.Add(new Order { Id = id, Price = 1.25M });
-                    id++;
-                }
-                for (int i = 0; i < 6000; i++)
-                {
-                    orders.Add(new Order { Id = id, Price = 15.35M });
-                    id++;
-                }
-                for (int i = 0; i < 6000; i++)
-                {
-                    orders.Add(new Order { Id = id, Price = 15.35M });
-                    id++;
-                }
-
-                Debug.WriteLine("Last Id for Order is {0}", id);
-                dbContext.BulkInsert(orders, new BulkInsertOptions<Order>() { KeepIdentity = true });
-                var products = new List<Product>();
-                id = 1;
-                for (int i = 0; i < 2050; i++)
-                {
-                    products.Add(new Product { Id = i.ToString(), Price = 1.25M, OutOfStock = false });
-                    id++;
-                }
-                for (int i = 2050; i < 7000; i++)
-                {
-                    products.Add(new Product { Id = i.ToString(), Price = 1.25M, OutOfStock = true });
-                    id++;
-                }
-
-                Debug.WriteLine("Last Id for Article is {0}", id);
-                dbContext.BulkInsert(products, new BulkInsertOptions<Product>() { KeepIdentity = false, AutoMapOutputIdentity = false });
-
-                //TPH Customers & Vendors
-                var tphCustomers = new List<TphCustomer>();
-                var tphVendors = new List<TphVendor>();
-                for (int i = 0; i < 2000; i++)
-                {
-                    tphCustomers.Add(new TphCustomer
+                        DateTime addedDateTime = DateTime.UtcNow.AddDays(-id);
+                        orders.Add(new Order
+                        {
+                            Id = id,
+                            ExternalId = string.Format("id-{0}", i),
+                            Price = 1.25M,
+                            AddedDateTime = addedDateTime,
+                            ModifiedDateTime = addedDateTime.AddHours(3)
+                        });
+                        id++;
+                    }
+                    for (int i = 0; i < 1050; i++)
                     {
-                        Id = i,
-                        FirstName = string.Format("John_{0}", i),
-                        LastName = string.Format("Smith_{0}", i),
-                        Email = string.Format("john.smith{0}@domain.com", i),
-                        Phone = "404-555-1111",
-                        AddedDate = DateTime.UtcNow
-                    });
-                }
-                for (int i = 2000; i < 3000; i++)
-                {
-                    tphVendors.Add(new TphVendor
+                        orders.Add(new Order { Id = id, Price = 5.35M });
+                        id++;
+                    }
+                    for (int i = 0; i < 2050; i++)
                     {
-                        Id = i,
-                        FirstName = string.Format("Mike_{0}", i),
-                        LastName = string.Format("Smith_{0}", i),
-                        Phone = "404-555-2222",
-                        Email = string.Format("mike.smith{0}@domain.com", i),
-                        Url = string.Format("http://domain.com/mike.smith{0}", i)
-                    });
+                        orders.Add(new Order { Id = id, Price = 1.25M });
+                        id++;
+                    }
+                    for (int i = 0; i < 6000; i++)
+                    {
+                        orders.Add(new Order { Id = id, Price = 15.35M });
+                        id++;
+                    }
+                    for (int i = 0; i < 6000; i++)
+                    {
+                        orders.Add(new Order { Id = id, Price = 15.35M });
+                        id++;
+                    }
+
+                    Debug.WriteLine("Last Id for Order is {0}", id);
+                    dbContext.BulkInsert(orders, new BulkInsertOptions<Order>() { KeepIdentity = true });
+                    var products = new List<Product>();
+                    id = 1;
+                    for (int i = 0; i < 2050; i++)
+                    {
+                        products.Add(new Product { Id = i.ToString(), Price = 1.25M, OutOfStock = false });
+                        id++;
+                    }
+                    for (int i = 2050; i < 7000; i++)
+                    {
+                        products.Add(new Product { Id = i.ToString(), Price = 1.25M, OutOfStock = true });
+                        id++;
+                    }
+
+                    Debug.WriteLine("Last Id for Article is {0}", id);
+                    dbContext.BulkInsert(products, new BulkInsertOptions<Product>() { KeepIdentity = false, AutoMapOutputIdentity = false });
                 }
-                dbContext.BulkInsert(tphCustomers, new BulkInsertOptions<TphCustomer>() { KeepIdentity = true });
-                dbContext.BulkInsert(tphVendors, new BulkInsertOptions<TphVendor>() { KeepIdentity = true });
+                else if (mode == PopulateDataMode.Tph)
+                {
+                    //TPH Customers & Vendors
+                    var tphCustomers = new List<TphCustomer>();
+                    var tphVendors = new List<TphVendor>();
+                    for (int i = 0; i < 2000; i++)
+                    {
+                        tphCustomers.Add(new TphCustomer
+                        {
+                            Id = i,
+                            FirstName = string.Format("John_{0}", i),
+                            LastName = string.Format("Smith_{0}", i),
+                            Email = string.Format("john.smith{0}@domain.com", i),
+                            Phone = "404-555-1111",
+                            AddedDate = DateTime.UtcNow
+                        });
+                    }
+                    for (int i = 2000; i < 3000; i++)
+                    {
+                        tphVendors.Add(new TphVendor
+                        {
+                            Id = i,
+                            FirstName = string.Format("Mike_{0}", i),
+                            LastName = string.Format("Smith_{0}", i),
+                            Phone = "404-555-2222",
+                            Email = string.Format("mike.smith{0}@domain.com", i),
+                            Url = string.Format("http://domain.com/mike.smith{0}", i)
+                        });
+                    }
+                    dbContext.BulkInsert(tphCustomers, new BulkInsertOptions<TphCustomer>() { KeepIdentity = true });
+                    dbContext.BulkInsert(tphVendors, new BulkInsertOptions<TphVendor>() { KeepIdentity = true });
+                }
+                else if (mode == PopulateDataMode.Tpc)
+                {
+                    //TPC Customers & Vendors
+                    var tpcCustomers = new List<TpcCustomer>();
+                    var tpcVendors = new List<TpcVendor>();
+                    for (int i = 0; i < 2000; i++)
+                    {
+                        tpcCustomers.Add(new TpcCustomer
+                        {
+                            Id = i,
+                            FirstName = string.Format("John_{0}", i),
+                            LastName = string.Format("Smith_{0}", i),
+                            Email = string.Format("john.smith{0}@domain.com", i),
+                            Phone = "404-555-1111",
+                            AddedDate = DateTime.UtcNow
+                        });
+                    }
+                    for (int i = 2000; i < 3000; i++)
+                    {
+                        tpcVendors.Add(new TpcVendor
+                        {
+                            Id = i,
+                            FirstName = string.Format("Mike_{0}", i),
+                            LastName = string.Format("Smith_{0}", i),
+                            Phone = "404-555-2222",
+                            Email = string.Format("mike.smith{0}@domain.com", i),
+                            Url = string.Format("http://domain.com/mike.smith{0}", i)
+                        });
+                    }
+                    dbContext.BulkInsert(tpcCustomers, new BulkInsertOptions<TpcCustomer>() { KeepIdentity = true });
+                    dbContext.BulkInsert(tpcVendors, new BulkInsertOptions<TpcVendor>() { KeepIdentity = true });
+                }
             }
             return dbContext;
         }

--- a/N.EntityFramework.Extensions.Test/DbContextExtensions/Fetch.cs
+++ b/N.EntityFramework.Extensions.Test/DbContextExtensions/Fetch.cs
@@ -52,5 +52,29 @@ namespace N.EntityFramework.Extensions.Test.DbContextExtensions
             Assert.IsTrue(expectedTotalCount == totalCount, "The total number of rows fetched must match the count of existing rows in database");
             Assert.IsTrue(expectedBatchCount == batchCount, "The total number of batches fetched must match what is expected");
         }
+        [TestMethod]
+        public void With_Options_InputColumns()
+        {
+            var dbContext = SetupDbContext(true);
+            int batchSize = 1000;
+            int batchCount = 0;
+            int totalCount = 0;
+            var orders = dbContext.Orders.Where(o => o.Price < 10M);
+            int expectedTotalCount = orders.Count();
+            int expectedBatchCount = (int)Math.Ceiling(expectedTotalCount / (decimal)batchSize);
+
+            orders.Fetch(result =>
+            {
+                batchCount++;
+                totalCount += result.Results.Count();
+                bool isAllExternalIdNull = !result.Results.Any(o => o.ExternalId != null);
+                Assert.IsTrue(isAllExternalIdNull, "All records should have ExternalId equal to NULL since it was not loaded.");
+                Assert.IsTrue(result.Results.Count <= batchSize, "The count of results in each batch callback should less than or equal to the batchSize");
+            }, options => { options.BatchSize = batchSize; options.InputColumns = s => new { s.Id, s.Price }; });
+
+            Assert.IsTrue(expectedTotalCount > 0, "There must be orders in database that match this condition");
+            Assert.IsTrue(expectedTotalCount == totalCount, "The total number of rows fetched must match the count of existing rows in database");
+            Assert.IsTrue(expectedBatchCount == batchCount, "The total number of batches fetched must match what is expected");
+        }
     }
 }

--- a/N.EntityFramework.Extensions.Test/Tests/DbContextExtensionsTest.cs
+++ b/N.EntityFramework.Extensions.Test/Tests/DbContextExtensionsTest.cs
@@ -13,7 +13,6 @@ using N.EntityFramework.Extensions.Test.Data;
 
 namespace N.EntityFramework.Extensions.Test.Tests
 {
-    [TestClass]
     public class DbContextExtensionsTest
     {
         //[TestMethod]
@@ -36,74 +35,6 @@ namespace N.EntityFramework.Extensions.Test.Tests
         //    Assert.IsTrue(rowsInserted == orders.Count, "The number of rows inserted must match the count of order list");
         //    Assert.IsTrue(newTotal - oldTotal == rowsInserted, "The new count minus the old count should match the number of rows inserted.");
         //}
-        [TestMethod]
-        public void BulkDelete()
-        {
-            var dbContext = SetupDbContext(true);
-            var orders = dbContext.Orders.Where(o => o.Price == 1.25M).ToList();
-            int rowsDeleted = dbContext.BulkDelete(orders);
-            int newTotal = dbContext.Orders.Where(o => o.Price == 1.25M).Count();
-
-            Assert.IsTrue(orders.Count > 0, "There must be orders in database that match this condition (Price < $2)");
-            Assert.IsTrue(rowsDeleted == orders.Count, "The number of rows deleted must match the count of existing rows in database");
-            Assert.IsTrue(newTotal == 0, "Must be 0 to indicate all records were deleted");
-        }
-        [TestMethod]
-        public void BulkDelete_With_Transaction()
-        {
-            var dbContext = SetupDbContext(true);
-            var orders = dbContext.Orders.Where(o => o.Price == 1.25M).ToList();
-            int rowsDeleted, newTotal = 0;
-            using (var transaction = dbContext.Database.BeginTransaction())
-            {
-                rowsDeleted = dbContext.BulkDelete(orders);
-                newTotal = dbContext.Orders.Where(o => o.Price == 1.25M).Count();
-                transaction.Rollback();
-            }
-            var rollbackTotal = dbContext.Orders.Count(o => o.Price == 1.25M);
-
-            Assert.IsTrue(orders.Count > 0, "There must be orders in database that match this condition (Price < $2)");
-            Assert.IsTrue(rowsDeleted == orders.Count, "The number of rows deleted must match the count of existing rows in database");
-            Assert.IsTrue(newTotal == 0, "Must be 0 to indicate all records were deleted");
-            Assert.IsTrue(rollbackTotal == orders.Count, "The number of rows after the transacation has been rollbacked should match the original count");
-        }
-        [TestMethod]
-        public void BulkDelete_Tpc()
-        {
-            var dbContext = SetupDbContext(true);
-            var customers = dbContext.TpcPeople.OfType<TpcCustomer>().ToList();
-            int rowsDeleted = dbContext.BulkDelete(customers, options => { options.DeleteOnCondition = (s, t) => s.Id == t.Id; });
-            var newCustomers = dbContext.TpcPeople.OfType<TpcCustomer>().Count();
-
-            Assert.IsTrue(customers.Count > 0, "There must be tpcCustomer records in database");
-            Assert.IsTrue(rowsDeleted == customers.Count, "The number of rows deleted must match the count of existing rows in database");
-            Assert.IsTrue(newCustomers == 0, "Must be 0 to indicate all records were deleted");
-        }
-        [TestMethod]
-        public void BulkDelete_Tph()
-        {
-            var dbContext = SetupDbContext(true);
-            var customers = dbContext.TphPeople.OfType<TphCustomer>().ToList();
-            int rowsDeleted = dbContext.BulkDelete(customers);
-            var newCustomers = dbContext.TphPeople.OfType<TphCustomer>().Count();
-
-            Assert.IsTrue(customers.Count > 0, "There must be tphCustomer records in database");
-            Assert.IsTrue(rowsDeleted == customers.Count, "The number of rows deleted must match the count of existing rows in database");
-            Assert.IsTrue(newCustomers == 0, "Must be 0 to indicate all records were deleted");
-        }
-        [TestMethod]
-        public void BulkDelete_Options_DeleteOnCondition()
-        {
-            var dbContext = SetupDbContext(true);
-            int oldTotal = dbContext.Orders.Where(o => o.Price == 1.25M).Count();
-            var orders = dbContext.Orders.Where(o => o.Price == 1.25M && o.ExternalId != null).ToList();
-            int rowsDeleted = dbContext.BulkDelete(orders, options => { options.DeleteOnCondition = (s, t) => s.ExternalId == t.ExternalId; options.UsePermanentTable = true; });
-            int newTotal = dbContext.Orders.Where(o => o.Price == 1.25M).Count();
-
-            Assert.IsTrue(orders.Count > 0, "There must be orders in database that match this condition (Price < $2)");
-            Assert.IsTrue(rowsDeleted == orders.Count, "The number of rows deleted must match the count of existing rows in database");
-            Assert.IsTrue(newTotal == oldTotal - rowsDeleted, "Must be 0 to indicate all records were deleted");
-        }
         [TestMethod]
         public void BulkInsert()
         {

--- a/N.EntityFramework.Extensions/Data/BulkUpdateOptions.cs
+++ b/N.EntityFramework.Extensions/Data/BulkUpdateOptions.cs
@@ -5,7 +5,9 @@ namespace N.EntityFramework.Extensions
 {
     public class BulkUpdateOptions<T> : BulkOptions
     {
-        public Expression<Func<T, object>> IgnoreColumnsOnUpdate { get; set; }
+        public Expression<Func<T, object>> IgnoreColumns { get; set; }
+        [Obsolete("BulkUpdateOptions.IgnoreColumnsOnUpdate has been replaced by IgnoreColumns.")]
+        public Expression<Func<T, object>> IgnoreColumnsOnUpdate { get { return IgnoreColumns; } set { IgnoreColumns = value; } }
         public Expression<Func<T, T, bool>> UpdateOnCondition { get; set; }
     }
 }

--- a/N.EntityFramework.Extensions/Data/DbContextExtensions.cs
+++ b/N.EntityFramework.Extensions/Data/DbContextExtensions.cs
@@ -352,7 +352,7 @@ namespace N.EntityFramework.Extensions
                     context.Database.CloneTable(destinationTableName, stagingTableName);
                     BulkInsert(entities, options, tableMapping, dbConnection, transaction, stagingTableName, null, SqlBulkCopyOptions.KeepIdentity);
 
-                    IEnumerable<string> columnstoUpdate = CommonUtil.FormatColumns(columnNames.Where(o => !options.IgnoreColumnsOnUpdate.GetObjectProperties().Contains(o)));
+                    IEnumerable<string> columnstoUpdate = CommonUtil.FormatColumns(columnNames.Where(o => !options.IgnoreColumns.GetObjectProperties().Contains(o)));
 
                     string updateSetExpression = string.Join(",", columnstoUpdate.Select(o => string.Format("t.{0}=s.{0}", o)));
                     string updateSql = string.Format("UPDATE t SET {0} FROM {1} AS s JOIN {2} AS t ON {3}; SELECT @@RowCount;",

--- a/N.EntityFramework.Extensions/Data/DbContextExtensionsAsync.cs
+++ b/N.EntityFramework.Extensions/Data/DbContextExtensionsAsync.cs
@@ -402,7 +402,7 @@ namespace N.EntityFramework.Extensions
                     context.Database.CloneTable(destinationTableName, stagingTableName);
                     await BulkInsertAsync(entities, options, tableMapping, dbConnection, transaction, stagingTableName, null, SqlBulkCopyOptions.KeepIdentity);
 
-                    IEnumerable<string> columnstoUpdate = CommonUtil.FormatColumns(columnNames.Where(o => !options.IgnoreColumnsOnUpdate.GetObjectProperties().Contains(o)));
+                    IEnumerable<string> columnstoUpdate = CommonUtil.FormatColumns(columnNames.Where(o => !options.IgnoreColumns.GetObjectProperties().Contains(o)));
 
                     string updateSetExpression = string.Join(",", columnstoUpdate.Select(o => string.Format("t.{0}=s.{0}", o)));
                     string updateSql = string.Format("UPDATE t SET {0} FROM {1} AS s JOIN {2} AS t ON {3}; SELECT @@RowCount;",

--- a/N.EntityFramework.Extensions/Extensions/LinqExtensions.cs
+++ b/N.EntityFramework.Extensions/Extensions/LinqExtensions.cs
@@ -106,13 +106,17 @@ namespace N.EntityFramework.Extensions
             {
                 return new List<string>();
             }
-            else if (expression.Body.Type == typeof(string))
+            else if (expression.Body is MemberExpression propertyExpression)
             {
-                return new List<string>() { ((PropertyInfo)expression.Body.GetPrivateFieldValue("Member")).Name };
+                return new List<string>() { propertyExpression.Member.Name };
             } 
+            else if (expression.Body is NewExpression newExpression)
+            {
+                return newExpression.Members.Select(o => o.Name).ToList();
+            }
             else
             {
-                return expression.Body.Type.GetProperties().Select(o => o.Name).ToList();
+                throw new InvalidOperationException("GetObjectProperties() encountered an unsupported expression type");
             }
         }
         internal static string ToSqlPredicate<T>(this Expression<T> expression, params string[] parameters)

--- a/N.EntityFramework.Extensions/N.EntityFramework.Extensions.csproj
+++ b/N.EntityFramework.Extensions/N.EntityFramework.Extensions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.1</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <Version>1.5.9</Version>
+    <Version>1.6.0</Version>
     <Company>NorthernLight1</Company>
     <Copyright>Copyright ©  2022</Copyright>
     <Description>Entity Framework Extensions extends your DbContext with high-performance bulk operations: BulkDelete, BulkInsert, BulkMerge, BulkSync, BulkUpdate, Fetch, FromSqlQuery, DeleteFromQuery, InsertFromQuery, UpdateFromQuery, QueryToCsvFile, SqlQueryToCsvFile.


### PR DESCRIPTION
Added new test case Fetch.With_Options_InputColumns
Refactored SetupDbContext() so that TPH and TPC are only executed for relevant tests
Fixed LinqExtensions.GetObjectProperties() so it correctly tests and assigns the correct type when pulling expression member data
Updated Nuget version to 1.6.0