### PR TITLE
Fixed BulkInsertAsync so that it clones the source table with the selected input columns if provided

### DIFF
--- a/N.EntityFramework.Extensions/Data/DbContextExtensionsAsync.cs
+++ b/N.EntityFramework.Extensions/Data/DbContextExtensionsAsync.cs
@@ -158,7 +158,7 @@ namespace N.EntityFramework.Extensions
                     IEnumerable<string> columnsToInsert = CommonUtil.FormatColumns(columnNames);
                     columnNames = columnNames.Union(storeGeneratedColumnNames);
 
-                    context.Database.CloneTable(destinationTableName, stagingTableName, null, Common.Constants.InternalId_ColumnName);
+                    context.Database.CloneTable(destinationTableName, stagingTableName, columnNames, Common.Constants.InternalId_ColumnName);
                     var bulkInsertResult = await BulkInsertAsync(entities, options, tableMapping, dbConnection, transaction, stagingTableName, columnNames, SqlBulkCopyOptions.KeepIdentity, true, true, cancellationToken);
 
                     List<string> columnsToOutput = new List<string> { "$Action", string.Format("{0}.{1}", "s", Constants.InternalId_ColumnName) };

--- a/N.EntityFramework.Extensions/N.EntityFramework.Extensions.csproj
+++ b/N.EntityFramework.Extensions/N.EntityFramework.Extensions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.1</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <Version>1.6.1</Version>
+    <Version>1.6.3</Version>
     <Company>NorthernLight1</Company>
     <Copyright>Copyright ©  2022</Copyright>
     <Description>Entity Framework Extensions extends your DbContext with high-performance bulk operations: BulkDelete, BulkInsert, BulkMerge, BulkSync, BulkUpdate, Fetch, FromSqlQuery, DeleteFromQuery, InsertFromQuery, UpdateFromQuery, QueryToCsvFile, SqlQueryToCsvFile.

--- a/N.EntityFramework.Extensions/Util/CommonUtil.cs
+++ b/N.EntityFramework.Extensions/Util/CommonUtil.cs
@@ -19,9 +19,9 @@ namespace N.EntityFramework.Extensions.Util
                 tableName = string.Format("[{0}].[#tmp_be_xx_{1}]", tableMapping.Schema, tableMapping.TableName);
             return tableName;
         }
-        internal static IEnumerable<string> FormatColumns(IEnumerable<string> enumerable)
+        internal static IEnumerable<string> FormatColumns(IEnumerable<string> columns)
         {
-            return enumerable.Select(s => string.Format("[{0}]", s));
+            return columns.Select(s => s.StartsWith("[") && s.EndsWith("]") ? s : string.Format("[{0}]", s));
         }
     }
     internal static class CommonUtil<T>


### PR DESCRIPTION
Updated nuget version to 1.6.3
Fixed BulkInsertAsync so that it clones the source table with the selected input columns if provided