### PR TITLE
Handle values to be Enum

### DIFF
--- a/N.EntityFramework.Extensions/Extensions/LinqExtensions.cs
+++ b/N.EntityFramework.Extensions/Extensions/LinqExtensions.cs
@@ -95,7 +95,10 @@ namespace N.EntityFramework.Extensions
                 return b ? "1" : "0";
             if (value is DateTime dt)
                 return "'" + dt.ToString("yyyy-MM-ddTHH:mm:ss.fff") + "'"; // Convert to ISO-8601
-            if (!value.GetType().IsClass)
+            var valueType = value.GetType();
+            if (valueType.IsEnum)
+                return Convert.ToString((int)value, CultureInfo.InvariantCulture);
+            if (!valueType.IsClass)
                 return Convert.ToString(value, CultureInfo.InvariantCulture);
 
             throw new NotImplementedException("Unhandled data type.");


### PR DESCRIPTION
In an update like that
```csharp
queryable.UpdateFromQuery(r => new MyObject { EnuymProm = MyEnum.MyEnumValue })
```

Without that change, enum values are taken as string, resulting in a wrong SQL Query.
```sql
UPDATE xxx SET Field=MyEnumValue
```

This change will convert `MyEnumValue` to its integer value, so the query will be
```sql
UPDATE xxx SET Field=42
```