### PR TITLE
Handle enum values in ConvertToSqlValue

### DIFF
--- a/N.EntityFramework.Extensions.Test/Data/Product.cs
+++ b/N.EntityFramework.Extensions.Test/Data/Product.cs
@@ -16,6 +16,7 @@ namespace N.EntityFramework.Extensions.Test.Data
         [Column("Status")]
         [StringLength(25)]
         public string StatusString { get; set; }
+        public ProductStatus? StatusEnum { get; set; }
         public DateTime? UpdatedDateTime { get; set; }
         [Timestamp]
         public byte[] RowVersion { get; set; }

--- a/N.EntityFramework.Extensions.Test/Data/ProductStatus.cs
+++ b/N.EntityFramework.Extensions.Test/Data/ProductStatus.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace N.EntityFramework.Extensions.Test.Data
+{
+    public enum ProductStatus
+    {
+        InStock,
+        OutOfStock,
+    }
+}

--- a/N.EntityFramework.Extensions.Test/DbContextExtensions/UpdateFromQuery.cs
+++ b/N.EntityFramework.Extensions.Test/DbContextExtensions/UpdateFromQuery.cs
@@ -12,6 +12,21 @@ namespace N.EntityFramework.Extensions.Test.DbContextExtensions
     public class UpdateFromQuery : DbContextExtensionsBase
     {
         [TestMethod]
+        public void With_Enum_Value()
+        {
+            var dbContext = SetupDbContext(true);
+            int oldTotal = dbContext.Products.Count(a => a.StatusEnum == null && a.OutOfStock);
+            int rowUpdated = dbContext.Products.Where(a => a.StatusEnum == null && a.OutOfStock)
+                .UpdateFromQuery(a => new Product { StatusEnum = ProductStatus.OutOfStock });
+            int newTotal = dbContext.Products.Count(o => o.StatusEnum == null && o.OutOfStock);
+            int newTotal2 = dbContext.Products.Count(o => o.StatusEnum == ProductStatus.OutOfStock && o.OutOfStock);
+
+            Assert.IsTrue(oldTotal > 0, "There must be articles in database that match this condition (OutOfStock == true)");
+            Assert.IsTrue(rowUpdated == oldTotal, "The number of rows update must match the count of rows that match the condition (OutOfStock == false)");
+            Assert.IsTrue(newTotal == 0, "The new count must be 0 to indicate all records were updated");
+            Assert.IsTrue(newTotal2 == oldTotal, "All rows must have been updated");
+        }
+        [TestMethod]
         public void With_Boolean_Value()
         {
             var dbContext = SetupDbContext(true);

--- a/N.EntityFramework.Extensions.Test/DbContextExtensions/UpdateFromQueryAsync.cs
+++ b/N.EntityFramework.Extensions.Test/DbContextExtensions/UpdateFromQueryAsync.cs
@@ -13,6 +13,21 @@ namespace N.EntityFramework.Extensions.Test.DbContextExtensions
     public class UpdateFromQueryAsync : DbContextExtensionsBase
     {
         [TestMethod]
+        public async Task With_Enum_Value()
+        {
+            var dbContext = SetupDbContext(true);
+            int oldTotal = dbContext.Products.Count(a => a.StatusEnum == null && a.OutOfStock);
+            int rowUpdated = await dbContext.Products.Where(a => a.StatusEnum == null && a.OutOfStock)
+                .UpdateFromQueryAsync(a => new Product { StatusEnum = ProductStatus.OutOfStock });
+            int newTotal = dbContext.Products.Count(o => o.StatusEnum == null && o.OutOfStock);
+            int newTotal2 = dbContext.Products.Count(o => o.StatusEnum == ProductStatus.OutOfStock && o.OutOfStock);
+
+            Assert.IsTrue(oldTotal > 0, "There must be articles in database that match this condition (OutOfStock == true)");
+            Assert.IsTrue(rowUpdated == oldTotal, "The number of rows update must match the count of rows that match the condition (OutOfStock == false)");
+            Assert.IsTrue(newTotal == 0, "The new count must be 0 to indicate all records were updated");
+            Assert.IsTrue(newTotal2 == oldTotal, "All rows must have been updated");
+        }
+        [TestMethod]
         public async Task With_Boolean_Value()
         {
             var dbContext = SetupDbContext(true);

--- a/N.EntityFramework.Extensions/Extensions/LinqExtensions.cs
+++ b/N.EntityFramework.Extensions/Extensions/LinqExtensions.cs
@@ -95,7 +95,10 @@ namespace N.EntityFramework.Extensions
                 return b ? "1" : "0";
             if (value is DateTime dt)
                 return "'" + dt.ToString("yyyy-MM-ddTHH:mm:ss.fff") + "'"; // Convert to ISO-8601
-            if (!value.GetType().IsClass)
+            var valueType = value.GetType();
+            if (valueType.IsEnum)
+                return Convert.ToString((int)value, CultureInfo.InvariantCulture);
+            if (!valueType.IsClass)
                 return Convert.ToString(value, CultureInfo.InvariantCulture);
 
             throw new NotImplementedException("Unhandled data type.");


### PR DESCRIPTION
In an update like that
```csharp
queryable.UpdateFromQuery(r => new MyObject { EnuymProm = MyEnum.MyEnumValue })
```

Without that change, enum values are taken as string, resulting in a wrong SQL Query.
```sql
UPDATE xxx SET Field=MyEnumValue
```

This change will convert `MyEnumValue` to its integer value, so the query will be
```sql
UPDATE xxx SET Field=42
```