### PR TITLE
Fix GetTableAlias with one-to-one relationship

### DIFF
--- a/N.EntityFramework.Extensions.Test/Data/Product.cs
+++ b/N.EntityFramework.Extensions.Test/Data/Product.cs
@@ -19,6 +19,7 @@ namespace N.EntityFramework.Extensions.Test.Data
         public DateTime? UpdatedDateTime { get; set; }
         [Timestamp]
         public byte[] RowVersion { get; set; }
+        public ProductProperty Properties { get; set; }
         public Product()
         {
 

--- a/N.EntityFramework.Extensions.Test/Data/ProductProperty.cs
+++ b/N.EntityFramework.Extensions.Test/Data/ProductProperty.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace N.EntityFramework.Extensions.Test.Data
+{
+    public class ProductProperty
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.None)]
+        public string Id { get; set; }
+
+        public string Description { get; set; }
+        public string OtherProperty { get; set; }
+
+        public Product Product { get; set; }
+    }
+}

--- a/N.EntityFramework.Extensions.Test/Data/TestDbContext.cs
+++ b/N.EntityFramework.Extensions.Test/Data/TestDbContext.cs
@@ -15,6 +15,7 @@ namespace N.EntityFramework.Extensions.Test.Data
         public virtual DbSet<TphPerson> TphPeople { get; set; }
         public virtual DbSet<TphCustomer> TphCustomers { get; set; }
         public virtual DbSet<TphVendor> TphVendors { get; set; }
+        public virtual DbSet<ProductProperty> ProductProperties { get; set; }
 
         public TestDbContext() : base(_connectionString)
         {
@@ -22,6 +23,8 @@ namespace N.EntityFramework.Extensions.Test.Data
         }
         protected override void OnModelCreating(DbModelBuilder modelBuilder)
         {
+            modelBuilder.Entity<Product>().HasOptional(p => p.Properties).WithRequired(p => p.Product);
+
         	//modelBuilder.Entity<TphPerson>().Property<DateTime>("CreatedDate");
             modelBuilder.Entity<TpcCustomer>().Map(m =>
             {

--- a/N.EntityFramework.Extensions.Test/DbContextExtensions/DbContextExtensionsBase.cs
+++ b/N.EntityFramework.Extensions.Test/DbContextExtensions/DbContextExtensionsBase.cs
@@ -25,7 +25,8 @@ namespace N.EntityFramework.Extensions.Test.DbContextExtensions
         {
             var dbContext = new TestDbContext();
             dbContext.Orders.Truncate();
-            dbContext.Products.Truncate();
+            dbContext.Database.ClearTable("ProductProperties");
+            dbContext.Database.ClearTable("Products");
             dbContext.ProductsWithComplexKey.Truncate();
             dbContext.Database.ClearTable("TphPeople");
             dbContext.Database.ClearTable("TpcCustomer");

--- a/N.EntityFramework.Extensions.Test/DbContextExtensions/UpdateFromQueryAsync.cs
+++ b/N.EntityFramework.Extensions.Test/DbContextExtensions/UpdateFromQueryAsync.cs
@@ -198,5 +198,22 @@ namespace N.EntityFramework.Extensions.Test.DbContextExtensions
             Assert.IsTrue(rowUpdated == oldTotal, "The number of rows update must match the count of rows that match the condition (Price < 10)");
             Assert.IsTrue(newTotal == 0, "The new count must be 0 to indicate all records were updated");
         }
+
+        [TestMethod]
+        public async Task With_OneToOneRelationship()
+        {
+            var dbContext = SetupDbContext(true);
+
+            dbContext.Products.Add(new Product { Id = "42M", Price = 42M, OutOfStock = false, Properties = new ProductProperty { Description = null } });
+            dbContext.SaveChanges();
+
+            var oldTotal = dbContext.ProductProperties.Where(p => p.Product.Price == 42M && p.Description == null).Count();
+            int rowUpdated = await dbContext.ProductProperties.Where(p => p.Product.Price == 42M).UpdateFromQueryAsync(a => new ProductProperty { Description = "42M" });
+            var newTotal = dbContext.ProductProperties.Where(p => p.Product.Price == 42M && p.Description == null).Count();
+
+            Assert.IsTrue(oldTotal > 0, "There must be product properties in database that match this condition (Description == null)");
+            Assert.IsTrue(rowUpdated == oldTotal, "The number of rows update must match the count of rows that match the condition (Url == null)");
+            Assert.IsTrue(newTotal == 0, "The new count must be 0 to indicate all records were updated");
+        }
     }
 }

--- a/N.EntityFramework.Extensions/Sql/SqlBuilder.cs
+++ b/N.EntityFramework.Extensions/Sql/SqlBuilder.cs
@@ -67,8 +67,9 @@ namespace N.EntityFramework.Extensions.Sql
         public String GetTableAlias()
         {
             var sqlFromClause = Clauses.First(o => o.Name == "FROM");
-            var startIndex = sqlFromClause.InputText.LastIndexOf(" AS ");
-            return startIndex > 0 ? sqlFromClause.InputText.Substring(startIndex + 4) : "";
+            var startIndex = sqlFromClause.InputText.IndexOf(" AS ") + 4;
+            var endIndex = sqlFromClause.InputText.IndexOf(']', startIndex) - startIndex + 1;
+            return startIndex > 4 ? sqlFromClause.InputText.Substring(startIndex, endIndex) : "";
         }
         public override string ToString()
         {


### PR DESCRIPTION
With a one-to-one relationship, updating the "dependant" entry with a criteria on the "parent" entity results in a WHERE clause like this one
```sql
FROM [dbo].[ChildEntity] AS [Extent1]     INNER JOIN [dbo].[ParentEntity] AS [Extent2] ON [Extent2].[Id] = [Extent1].[Id]
```

The `SqlBuilder.GetTableAlias()` function returns something like `[Extent2] ON [Extent2].[Id] = [Extent1].[Id]`, which is wrong.
