### PR TITLE
add support for Microsoft.Data.SqlClient inside EntityConnection

### DIFF
--- a/N.EntityFramework.Extensions/Sql/SqlBuilder.cs
+++ b/N.EntityFramework.Extensions/Sql/SqlBuilder.cs
@@ -104,13 +104,13 @@ namespace N.EntityFramework.Extensions.Sql
                 foreach (var parameter in objectQuery.Parameters)
                 {
                     DbParameter sqlParameter;
+                    DbConnection connection = objectQuery.Context.Connection is System.Data.Entity.Core.EntityClient.EntityConnection entityConnection ? entityConnection.StoreConnection : objectQuery.Context.Connection;
 
-                    if (objectQuery.Context.Connection is System.Data.SqlClient.SqlConnection ||
-                        objectQuery.Context.Connection is System.Data.Entity.Core.EntityClient.EntityConnection)
+                    if (connection is System.Data.SqlClient.SqlConnection)
                     {
                         sqlParameter = new System.Data.SqlClient.SqlParameter(parameter.Name, parameter.Value);
                     }
-                    else if (objectQuery.Context.Connection is Microsoft.Data.SqlClient.SqlConnection)
+                    else if (connection is Microsoft.Data.SqlClient.SqlConnection)
                     {
                         sqlParameter = new Microsoft.Data.SqlClient.SqlParameter(parameter.Name, parameter.Value);
                     }


### PR DESCRIPTION
We are trying to port our .net framework app to .net 8.0 and ran into this issue. So far [N.EntityFramework.Extensions](https://github.com/NorthernLight1/N.EntityFramework.Extensions) only supports new MSSql driver if used standalone but not inside EntityConnection. This PR fixes that.

Would be awesome if you could build a new nuget version if this PR seems reasonable for you :)