### PR TITLE
Fixed an issue with UpdateFromQuery/Async for string literals

### DIFF
--- a/N.EntityFramework.Extensions.Test/DbContextExtensions/UpdateFromQuery.cs
+++ b/N.EntityFramework.Extensions.Test/DbContextExtensions/UpdateFromQuery.cs
@@ -211,6 +211,32 @@ public class UpdateFromQuery : DbContextExtensionsBase
         Assert.IsTrue(newTotal == 0, "The new count must be 0 to indicate all records were updated");
     }
     [TestMethod]
+    public void With_String_Containing_Dot()
+    {
+        var dbContext = SetupDbContext(true);
+        string email = "luciano.cravero@testmail.com";
+        int oldTotal = dbContext.Orders.Where(o => o.ExternalId == null).Count();
+        int rowUpdated = dbContext.Orders.Where(o => o.ExternalId == null).UpdateFromQuery(o => new Order { ExternalId = email, Active = false });
+        int newTotal = dbContext.Orders.Where(o => o.ExternalId == email).Count();
+
+        Assert.IsTrue(oldTotal > 0, "There must be orders in database that match this condition (ExternalId == null)");
+        Assert.IsTrue(rowUpdated == oldTotal, "The number of rows update must match the count of rows that match the condition (ExternalId == null)");
+        Assert.IsTrue(newTotal == rowUpdated, "The ExternalId must be saved exactly as provided, without any corruption from dot replacement");
+    }
+    [TestMethod]
+    public void With_String_Column_Copy()
+    {
+        var dbContext = SetupDbContext(true);
+        var orders = dbContext.Orders.Where(o => o.ExternalId != null);
+        int oldTotal = orders.Count();
+        int rowUpdated = orders.UpdateFromQuery(o => new Order { ExternalId = o.ExternalId + ".copy" });
+        int newTotal = dbContext.Orders.Where(o => o.ExternalId != null && o.ExternalId.EndsWith(".copy")).Count();
+
+        Assert.IsTrue(oldTotal > 0, "There must be orders in database that have an ExternalId");
+        Assert.IsTrue(rowUpdated == oldTotal, "The number of rows updated must match the count of rows that have an ExternalId");
+        Assert.IsTrue(newTotal == oldTotal, "All ExternalId values must have been updated using the column reference");
+    }
+    [TestMethod]
     public void With_Transaction()
     {
         var dbContext = SetupDbContext(true);

--- a/N.EntityFramework.Extensions.Test/DbContextExtensions/UpdateFromQueryAsync.cs
+++ b/N.EntityFramework.Extensions.Test/DbContextExtensions/UpdateFromQueryAsync.cs
@@ -225,6 +225,32 @@ public class UpdateFromQueryAsync : DbContextExtensionsBase
         Assert.IsTrue(newTotal == 0, "The new count must be 0 to indicate all records were updated");
     }
     [TestMethod]
+    public async Task With_String_Containing_Dot()
+    {
+        var dbContext = SetupDbContext(true);
+        string email = "luciano.cravero@testmail.com";
+        int oldTotal = dbContext.Orders.Where(o => o.ExternalId == null).Count();
+        int rowUpdated = await dbContext.Orders.Where(o => o.ExternalId == null).UpdateFromQueryAsync(o => new Order { ExternalId = email });
+        int newTotal = dbContext.Orders.Where(o => o.ExternalId == email).Count();
+
+        Assert.IsTrue(oldTotal > 0, "There must be orders in database that match this condition (ExternalId == null)");
+        Assert.IsTrue(rowUpdated == oldTotal, "The number of rows update must match the count of rows that match the condition (ExternalId == null)");
+        Assert.IsTrue(newTotal == rowUpdated, "The ExternalId must be saved exactly as provided, without any corruption from dot replacement");
+    }
+    [TestMethod]
+    public async Task With_String_Column_Copy()
+    {
+        var dbContext = SetupDbContext(true);
+        var orders = dbContext.Orders.Where(o => o.ExternalId != null);
+        int oldTotal = orders.Count();
+        int rowUpdated = await orders.UpdateFromQueryAsync(o => new Order { ExternalId = o.ExternalId + ".copy" });
+        int newTotal = dbContext.Orders.Where(o => o.ExternalId != null && o.ExternalId.EndsWith(".copy")).Count();
+
+        Assert.IsTrue(oldTotal > 0, "There must be orders in database that have an ExternalId");
+        Assert.IsTrue(rowUpdated == oldTotal, "The number of rows updated must match the count of rows that have an ExternalId");
+        Assert.IsTrue(newTotal == oldTotal, "All ExternalId values must have been updated using the column reference");
+    }
+    [TestMethod]
     public async Task With_Transaction()
     {
         var dbContext = SetupDbContext(true);

--- a/N.EntityFramework.Extensions/Extensions/LinqExtensions.cs
+++ b/N.EntityFramework.Extensions/Extensions/LinqExtensions.cs
@@ -5,12 +5,14 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 
 namespace N.EntityFramework.Extensions
 {
     static class LinqExtensions
     {
+        private static readonly Regex SqlStringLiteralRegex = new Regex(@"('(?:''|[^'])*')", RegexOptions.Compiled);
+
         internal static string GetExpressionValueAsString(MemberBinding binding)
         {
             return GetExpressionValueAsString(binding.GetPrivateFieldValue("Expression") as Expression);
@@ -148,14 +150,23 @@ namespace N.EntityFramework.Extensions
         {
             List<string> setValues = new List<string>();
             var memberInitExpression = expression.Body as MemberInitExpression;
+            string oldPrefix = expression.Parameters.First().Name + ".";
+            string newPrefix = tableName + ".";
             foreach (var binding in memberInitExpression.Bindings)
             {
                 string expValue = GetExpressionValueAsString(binding);
-                expValue = expValue.Replace(string.Format("{0}.", expression.Parameters.First().Name),
-                    string.Format("{0}.", tableName));
+                expValue = ReplaceOutsideSqlStringLiterals(expValue, oldPrefix, newPrefix);
                 setValues.Add(string.Format("{0}.[{1}]={2}", tableName, binding.Member.Name, expValue));
             }
             return string.Join(",", setValues);
+        }
+
+        private static string ReplaceOutsideSqlStringLiterals(string input, string oldValue, string newValue)
+        {
+            var parts = SqlStringLiteralRegex.Split(input);
+            for (int i = 0; i < parts.Length; i += 2)
+                parts[i] = parts[i].Replace(oldValue, newValue);
+            return string.Join("", parts);
         }
     }
 }


### PR DESCRIPTION
When we want to update some value, for example using this:

```  
await db.Users
     .Where(o => o.Id == requestAccount.Id)
     .UpdateFromQueryAsync(o => new Users { 
         Name = name,
         Surname = surname,
         Email = email,
         Initials = initials,
         Job = job,
         Password = newPassword,
         LastPasswordUpdate = DateTime.UtcNow
     });
     
 ```
 
 and the e-mail is something like 'luciano.cravero@testmail.com', the 'o.' part is replaced to [Extent1], producing an update that does not respect the original string.